### PR TITLE
Lra 376 permissions for different roles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem 'ruby-oci8', '~> 2.2', '>= 2.2.11'
 gem 'activerecord-oracle_enhanced-adapter', '~> 7.0', '>= 7.0.2'
 
 gem 'resolv', '~> 0.2.1'
+gem 'pundit', '~> 2.2'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'activerecord-oracle_enhanced-adapter', '~> 7.0', '>= 7.0.2'
 
 gem 'resolv', '~> 0.2.1'
 gem 'pundit', '~> 2.2'
-gem 'ldap_lookup'
+gem 'ldap_lookup', '~> 0.1.6'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'activerecord-oracle_enhanced-adapter', '~> 7.0', '>= 7.0.2'
 
 gem 'resolv', '~> 0.2.1'
 gem 'pundit', '~> 2.2'
+gem 'ldap_lookup'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    ldap_lookup (0.1.5)
+    ldap_lookup (0.1.6)
       net-ldap (~> 0.17.0)
     loofah (2.18.0)
       crass (~> 1.0.2)
@@ -241,7 +241,7 @@ DEPENDENCIES
   devise (~> 4.8)
   importmap-rails
   jbuilder
-  ldap_lookup
+  ldap_lookup (~> 0.1.6)
   omniauth-rails_csrf_protection
   omniauth-saml
   puma (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    importmap-rails (1.1.4)
+    importmap-rails (1.1.5)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.5.11)
@@ -102,6 +102,8 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    ldap_lookup (0.1.5)
+      net-ldap (~> 0.17.0)
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -116,6 +118,7 @@ GEM
       digest
       net-protocol
       strscan
+    net-ldap (0.17.1)
     net-pop (0.1.1)
       digest
       net-protocol
@@ -202,7 +205,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.4)
-    stimulus-rails (1.0.4)
+    stimulus-rails (1.1.0)
       railties (>= 6.0.0)
     strscan (3.0.3)
     tailwindcss-rails (2.0.10-x86_64-darwin)
@@ -213,7 +216,7 @@ GEM
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -238,6 +241,7 @@ DEPENDENCIES
   devise (~> 4.8)
   importmap-rails
   jbuilder
+  ldap_lookup
   omniauth-rails_csrf_protection
   omniauth-saml
   puma (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,8 @@ GEM
     orm_adapter (0.5.0)
     puma (5.6.4)
       nio4r (~> 2.0)
+    pundit (2.2.0)
+      activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.4)
     rack-protection (2.2.1)
@@ -226,6 +228,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-20
 
 DEPENDENCIES
@@ -238,6 +241,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   omniauth-saml
   puma (~> 5.0)
+  pundit (~> 2.2)
   rails (~> 7.0.3.1)
   ransack (~> 3.2, >= 3.2.1)
   redis (~> 4.0)
@@ -252,7 +256,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 3.0.2p107
+   ruby 3.1.0p0
 
 BUNDLED WITH
    2.2.29

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  include Pundit::Authorization
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::Base
   def set_membership
     if user_signed_in?
       current_user.membership = session[:user_memberships]
-      current_user.admin = session[:user_admin]
+      current_user.role = session[:user_role]
     else
       new_user_session_path
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,29 @@
 class ApplicationController < ActionController::Base
   include Pundit::Authorization
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_in_group
+  before_action :set_membership
+  after_action :verify_authorized, unless: :devise_controller?
+
+  private
+
+  def user_not_authorized
+    flash[:alert] = "Please sign in to perform this action."
+    redirect_to(request.referrer || root_path)
+  end
+
+  def user_not_in_group
+    flash[:alert] = "You are not authorized to perform this action."
+    redirect_to about_path
+  end
+
+  def set_membership
+    if user_signed_in?
+      current_user.membership = session[:user_memberships]
+      current_user.admin = session[:user_admin]
+    else
+      new_user_session_path
+    end
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   def user_not_in_group
     flash[:alert] = "You are not authorized to perform this action."
-    redirect_to about_path
+    redirect_to rooms_path
   end
 
   def set_membership

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,11 @@ class ApplicationController < ActionController::Base
 
   def user_not_in_group
     flash[:alert] = "You are not authorized to perform this action."
-    redirect_to rooms_path
+    if current_user.role == ""
+      redirect_to root_path
+    else
+      redirect_to room_path
+    end
   end
 
   def set_membership

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,8 +1,10 @@
 class DashboardController < ApplicationController
   include ApplicationHelper
+  before_action :authenticate_user!
 
   def index
    rooms =  Room.active
-    @rooms = rooms_need_attention(rooms)
+   @rooms = rooms_need_attention(rooms)
+   authorize :dashboard
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,6 @@
+class PagesController < ApplicationController
+
+  def home
+    authorize :page
+  end
+end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,4 +1,5 @@
 class RoomsController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_room, only: %i[ show edit update destroy ]
   include ApplicationHelper
 

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -31,6 +31,8 @@ class RoomsController < ApplicationController
       @rooms = rooms_need_attention(@rooms)
     end
 
+    authorize @rooms
+
     unless params[:q].nil?
       render turbo_stream: turbo_stream.replace(
       :roomListing,
@@ -46,6 +48,7 @@ class RoomsController < ApplicationController
   # GET /rooms/new
   def new
     @room = Room.new
+    authorize @room
   end
 
   # GET /rooms/1/edit
@@ -55,7 +58,7 @@ class RoomsController < ApplicationController
   # POST /rooms or /rooms.json
   def create
     @room = Room.new(room_params)
-
+    authorize @room
     room_data = get_room_data_from_oracle(room_params[:facility_id].upcase)
     if room_data.nil?
       flash.now[:alert] = "No data for this room in MPathways"
@@ -108,6 +111,7 @@ class RoomsController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_room
       @room = Room.find(params[:id])
+      authorize @room
     end
 
     def get_room_data_from_oracle(facility_id)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -49,6 +49,24 @@ def set_user
 
   if @user
     session[:user_email] = @user.email
+
+    membership = []
+    access_groups = ['LSA-AV-Monitoring-Admins', 'lsa-av-monitoring-tech', 'LSA-AV-Monitoring-Reviewers']
+    access_groups.each do |group|
+      if  LdapLookup.is_member_of_group?(@user.uniqname, group)
+        membership.append(group)
+      end
+    end
+    session[:user_memberships] = membership
+    if membership.include?('LSA-AV-Monitoring-Admins')
+      session[:user_role] = "admin"
+    elsif membership.include?('lsa-av-monitoring-tech')
+      session[:user_role] = "technician"
+    elsif membership.include?('LSA-AV-Monitoring-Reviewers')
+      session[:user_role] = "reviewer"
+    else
+      session[:user_role] = ""
+    end
   end
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [:saml]
+
+  attr_accessor :membership, :role
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -37,12 +37,11 @@ class ApplicationPolicy
   end
 
   def user_in_access_group?
-    if Rails.env.production?
-      true
-    else
-      access_groups = ['LSA-AV-Monitoring-Admins', 'lsa-av-monitoring-tech', 'LSA-AV-Monitoring-Reviewers']
-      user.membership && (user.membership & access_groups).any?
+    if user.role == ''
+      return false
     end
+    access_groups = ['LSA-AV-Monitoring-Admins', 'lsa-av-monitoring-tech', 'LSA-AV-Monitoring-Reviewers']
+    user.membership && (user.membership & access_groups).any?
   end
 
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -36,4 +36,13 @@ class ApplicationPolicy
     false
   end
 
+  def user_in_access_group?
+    if Rails.env.production?
+      true
+    else
+      access_groups = ['LSA-AV-Monitoring-Admins', 'lsa-av-monitoring-tech', 'LSA-AV-Monitoring-Reviewers']
+      user.membership && (user.membership & access_groups).any?
+    end
+  end
+
 end

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -1,0 +1,7 @@
+class DashboardPolicy < ApplicationPolicy
+
+  def index?
+    true
+  end
+
+end

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -1,7 +1,7 @@
 class DashboardPolicy < ApplicationPolicy
 
   def index?
-    true
+    user_in_access_group?
   end
 
 end

--- a/app/policies/page_policy.rb
+++ b/app/policies/page_policy.rb
@@ -1,0 +1,7 @@
+class PagePolicy < ApplicationPolicy
+
+  def home?
+    true
+  end
+
+end

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -1,0 +1,19 @@
+class RoomPolicy < ApplicationPolicy
+
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  def update?
+    true
+  end
+
+end

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -1,19 +1,27 @@
 class RoomPolicy < ApplicationPolicy
 
   def index?
-    true
+    user_in_access_group?
   end
 
   def show?
-    true
+    user_in_access_group?
+  end
+
+  def new?
+    create?
   end
 
   def create?
-    true
+    user.role == 'admin'
+  end
+
+  def edit?
+    update?
   end
 
   def update?
-    true
+    user.role == 'admin'
   end
 
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container px-1 mb-20 pl-4">
+<div class="container -mt-20 px-1 mb-20 pl-4">
   <h1 class="text-xl font-semibold text-gray-900 p-2">Dashboard - Rooms that need attention</h1>
 
   <div class="">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -26,7 +26,7 @@
                 <%= link_to "Find a Room", rooms_path %>
               </div>
             <% end %>
-            <% if user_signed_in? %>
+            <% if user_signed_in? && current_user.role == "admin" %>
               <div class="hover:underline">
                 <%= link_to 'New room', new_room_path %>
               </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,16 +16,22 @@
         </div>
         <div class="hidden sm:ml-6 sm:flex sm:space-x-4 pl-2">
           <div class="border-transparent text-blue-50 inline-flex items-center justify-between space-x-4 pl-1 pt-1 border-b-2 text-base font-normal">
-            <div class="hover:underline">
-               <%= link_to "Dashboard", dashboard_path %>
-            </div>
-            <div class="hover:underline">
-              <%= link_to "Find a Room", rooms_path %>
-            </div>
-            <div class="hover:underline">
-              <%= link_to 'New room', new_room_path %>
-            </div>
-            <div>
+            <% if user_signed_in? %>
+              <div class="hover:underline">
+                <%= link_to "Dashboard", dashboard_path %>
+              </div>
+            <% end %>
+            <% if user_signed_in? %>
+              <div class="hover:underline">
+                <%= link_to "Find a Room", rooms_path %>
+              </div>
+            <% end %>
+            <% if user_signed_in? %>
+              <div class="hover:underline">
+                <%= link_to 'New room', new_room_path %>
+              </div>
+            <% end %>
+            <div class="place-self-end">
               <% if user_signed_in? %>
                 <div class="text-yellow-400">
                   <%= current_user.email %> - <%= current_user.role %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -28,7 +28,7 @@
             <div>
               <% if user_signed_in? %>
                 <div class="text-yellow-400">
-                  <%= current_user.email %>
+                  <%= current_user.email %> - <%= current_user.role %>
                 </div>
                 <%= button_to destroy_user_session_path, method: :delete, tabindex: "-1", data: {turbo: "false"} do %>
                   <div>Sign Out</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,0 +1,10 @@
+<div class="container px-1 mb-20">
+
+  <h1> About The AV Monitoring application.</h1>
+
+  <% unless current_user %>
+    <%= button_to user_saml_omniauth_authorize_path, data: {turbo: "false"} do %>
+      <div class="mt-10 inline-block w-full bg-gray-900 border border-transparent rounded-md py-3 px-8 font-medium text-white hover:bg-gray-800 sm:w-auto mb-10 sm:mb-0 href="#">Log In To Find A Room!</div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container px-1 mb-20 pl-4" data-controller='autosubmit'>
+<div class="container px-1 -mt-20 mb-20 pl-4" data-controller='autosubmit'>
   <h1 class="text-xl font-semibold text-gray-900 p-2">Rooms with Crestron devices</h1>
   <div class="grid grid-cols-2 pb-2">
     <div class="justify-self-end lg:hidden mr-4">

--- a/app/views/rooms/new.html.erb
+++ b/app/views/rooms/new.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-auto md:w-2/3 w-full">
+<div class="container -mt-20 mx-auto md:w-2/3 w-full">
   <h1 class="font-bold text-4xl">New room</h1>
 
   <%= render "form", room: @room %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "room" do  %>
-  <div class="container rounded-lg shadow-lg px-auto pl-2">
+  <div class="container -mt-20 rounded-lg shadow-lg px-auto pl-2">
     <div class="flex-col w-full px-2">
-      <div class="mx-auto">
+      <div class="">
         <h1 class="text-3xl mb-2">
         <%= @room.display_name %>
         <% if room_need_attention?(@room) %>
@@ -23,7 +23,9 @@
       <% if room_has_device_states?(@room) %>
         <%= render @room %>
       <% end %>
-      <%= link_to 'Edit this room', edit_room_path(@room), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium", data: { "turbo-frame": "_top" } %>
+      <% if current_user.role == "admin" %>
+        <%= link_to 'Edit this room', edit_room_path(@room), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium", data: { "turbo-frame": "_top" } %>
+      <% end %>
       <%= link_to 'Back to rooms', rooms_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium", data: { "turbo-frame": "_top" } %>
     </div>
   </div>

--- a/config/initializers/ldap_lookup.rb
+++ b/config/initializers/ldap_lookup.rb
@@ -1,0 +1,7 @@
+LdapLookup.configuration do |config|
+  config.host = "ldap.umich.edu"
+  config.port =   "389" 
+  config.base =   "dc=umich,dc=edu"
+  config.dept_attribute =  "umichPostalAddressData"
+  config.group_attribute =   "umichGroupEmail"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'page/home'
   get 'dashboard', to: 'dashboard#index'
   devise_for :users, controllers: {omniauth_callbacks: "users/omniauth_callbacks", sessions: "users/sessions"} do
     delete 'sign_out', :to => 'users/sessions#destroy', :as => :destroy_user_session
@@ -7,5 +8,5 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")
-  root "rooms#index"
+  root "pages#home"
 end


### PR DESCRIPTION
Added pundit and ldap_lookup gems.
To the user model, added virtual attributes :membership, :role.
User's role is assigned based on the ldap group membership - see omniauth_callbacks_controller.rb file.
Created authorization policies: 

- admins can add and edit rooms; 
- non-admins don't see a New Room, Edit links, and can't go there directly; 
- nothing more yet.

Created a Home page.

To test users roles:

- We all are in admin group: LSA-AV-Monitoring-Admins
- I added um174887 to LSA-AV-Monitoring-Reviewers group and
- um171712 - to lsa-av-monitoring-tech group