### PR TITLE
set gem version explicilty

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "jbuilder"
 gem "ldap_lookup", "~> 0.1.6"
 # gem install mysql2 -v '0.5.4' -- --with-ldflags=-L/usr/local/opt/openssl/lib --with-cppflags=-I/usr/local/opt/openssl/include
 gem 'mysql2', '~> 0.5.4'
-gem "omniauth-saml"
+gem 'omniauth-saml', '~> 2.1'
 gem "omniauth-rails_csrf_protection"
 gem "puma", "~> 5.0"
 gem "pundit", "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ DEPENDENCIES
   ldap_lookup (~> 0.1.6)
   mysql2 (~> 0.5.4)
   omniauth-rails_csrf_protection
-  omniauth-saml
+  omniauth-saml (~> 2.1)
   puma (~> 5.0)
   pundit (~> 2.2)
   rails (~> 7.0.3.1)


### PR DESCRIPTION
due to the change in variable name for devise sso and slo I explicitly set the SAML gem version to prevent issues