### PR TITLE
Hide delete button on room

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -51,7 +51,7 @@ def set_user
     session[:user_email] = @user.email
 
     membership = []
-    access_groups = ['LSA-AV-Monitoring-Admins', 'lsa-av-monitoring-tech', 'LSA-AV-Monitoring-Viewer']
+    access_groups = ['LSA-AV-Monitoring-Admins', 'lsa-av-monitoring-tech', 'LSA-AV-Monitoring-Viewer', 'lsa-avm-special-ops']
     access_groups.each do |group|
       if  LdapLookup.is_member_of_group?(@user.uniqname, group)
         membership.append(group)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -208,4 +208,8 @@ module ApplicationHelper
     return attention_rooms
   end
 
+  def show_delete_button
+    current_user.uniqname == "rsmoke" ? true : false
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -209,7 +209,7 @@ module ApplicationHelper
   end
 
   def show_delete_button
-    current_user.uniqname == "rsmoke" ? true : false
+    session[:user_memberships].include?('lsa-avm-special-ops') ? true : false
   end
 
 end

--- a/app/views/rooms/_room_card.html.erb
+++ b/app/views/rooms/_room_card.html.erb
@@ -22,8 +22,10 @@
         </div>
         <hr>
       <% end %>
-      <hr>
-      <%= link_to "[Delete Room]", room_path(room), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "text-red-600" %>
+      <% if show_delete_button %>
+        <hr>
+        <%= link_to "[Delete Room]", room_path(room), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "text-red-600" %>
+      <% end %>
     </div>
   </li>
 <% end %>


### PR DESCRIPTION
I added a helper to √ for membership in a super secret MCommunity group and return true/false. I then √ for this value and display the room delete button accordingly.

I am not ready to get rid of this button but realize it should not be in the public interface